### PR TITLE
remove demo height param

### DIFF
--- a/web/src/js/views/read.tsx
+++ b/web/src/js/views/read.tsx
@@ -100,7 +100,7 @@ export default class Read extends Page<Props, State> {
 
         return <div className={s.reader}>
             <img
-                src={page.url + '?height=500'}
+                src={page.url}
                 className={s.imgResponsive}
                 useMap='#image-map'
                 ref={e => this.img = e}


### PR DESCRIPTION
Noticed that we never got rid of the hard-coded height parameter in the reader, this PR removes it.